### PR TITLE
Security: Update Node to V19.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Install dependencies only when needed
-FROM node:lts-alpine3.15 AS deps
+FROM node:19-alpine3.16 AS deps
 WORKDIR /app
 
 COPY package.json yarn.lock* package-lock.json* ./
@@ -11,7 +11,7 @@ RUN \
     fi;
 
 # Rebuild the source code only when needed
-FROM node:lts-alpine3.15 AS builder
+FROM node:19-alpine3.16 AS builder
 WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules
@@ -20,7 +20,7 @@ COPY . ./
 RUN yarn build
 
 # Production image, copy all the files and run node
-FROM node:lts-alpine3.15 AS runner
+FROM node:19-alpine3.16 AS runner
 WORKDIR /app
 
 ENV NODE_ENV production


### PR DESCRIPTION
This fixes CVE-2022-3786 and CVE-2022-3602.